### PR TITLE
perf: fix stale Jekyll exclude paths, trim ~740 KB from Pages deploys

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,16 +101,24 @@ reveal:
   minScale: 0.2
   maxScale: 1.5
 
+## Files kept in the repo (so GitHub Pages can serve reveal.js without an
+## npm install) but never referenced by the slideshow, so we keep them out of
+## the built _site to shrink each deploy. reveal.js now lives under
+## node_modules/reveal.js — the old "reveal.js/*" entries no longer matched
+## anything, so these paths had to be repointed for the excludes to take effect.
 exclude: [
   "Gemfile",
   "Gemfile.lock",
   "vendor",
-  "reveal.js/test",
-  "reveal.js/index.html",
-  "reveal.js/README.md",
-  "reveal.js/bower.json",
-  "reveal.js/Gruntfile.js",
-  "reveal.js/CONTRIBUTING.md",
-  "reveal.js/LICENSE",
-  "reveal.js/package.json"
+  "package-lock.json",
+  "node_modules/reveal.js/test",
+  "node_modules/reveal.js/css/theme/source",
+  "node_modules/reveal.js/index.html",
+  "node_modules/reveal.js/demo.html",
+  "node_modules/reveal.js/README.md",
+  "node_modules/reveal.js/bower.json",
+  "node_modules/reveal.js/Gruntfile.js",
+  "node_modules/reveal.js/CONTRIBUTING.md",
+  "node_modules/reveal.js/LICENSE",
+  "node_modules/reveal.js/package.json"
 ]


### PR DESCRIPTION
## Summary

Fixes the stale Jekyll `exclude:` list in `_config.yml` so GitHub Pages stops deploying ~740 KB of reveal.js files the slideshow never loads.

### The bug
The exclude list still pointed at the old submodule layout (`reveal.js/*`), but reveal.js now lives under `node_modules/reveal.js/`. None of the entries matched anything, so every deploy shipped the reveal.js test suite, theme SCSS sources, README/demo pages, and dev metadata.

### The fix
- Repointed every exclude entry at `node_modules/reveal.js/...`
- Added `test/` (~670 KB), `css/theme/source/` SCSS, `demo.html`, and `package-lock.json`

### Verification
- No excluded path is referenced anywhere in `_layouts`, `_includes`, or `index.html`
- All 9 assets the slideshow actually loads (reveal.js core, markdown/highlight/notes plugins, reveal/reset/moon/monokai/paper CSS) remain in the build

Zero visual or behavioral change for viewers — each Pages deploy just gets ~740 KB lighter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vpXKHgAZoPW4PmbiLQMGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019vpXKHgAZoPW4PmbiLQMGJ)_